### PR TITLE
Add php5-curl

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
     - php5-mysql
     - php5-gd
     - curl
+    - php5-curl
     # Below package are required for automated installation with ansible
     - python-mysqldb
     - expect


### PR DESCRIPTION
Without installation of php5-curl, the following error is given (via install script or vagrant): 

TASK: [snipeit-ansible | Install php requirements with composer] ************** 
failed: [default] => {"changed": true, "cmd": "php composer.phar install --prefer-source --no-interaction", "delta": "0:00:00.274098", "end": "2015-10-15 01:36:54.342744", "rc": 2, "start": "2015-10-15 01:36:54.068646", "warnings": []}
stderr: Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for guzzle/guzzle 3.9.x-dev -> satisfiable by guzzle/guzzle[3.9.x-dev].
    - guzzle/guzzle 3.9.x-dev requires ext-curl * -> the requested PHP extension curl is missing from your system.
  Problem 2
    - Installation request for guzzle/guzzle dev-master -> satisfiable by guzzle/guzzle[dev-master].
    - guzzle/guzzle dev-master requires ext-curl * -> the requested PHP extension curl is missing from your system.
  Problem 3
    - guzzle/guzzle 3.9.x-dev requires ext-curl * -> the requested PHP extension curl is missing from your system.
    - aws/aws-sdk-php 2.8.x-dev requires guzzle/guzzle ~3.7 -> satisfiable by guzzle/guzzle[3.9.x-dev].
    - Installation request for aws/aws-sdk-php 2.8.x-dev -> satisfiable by aws/aws-sdk-php[2.8.x-dev].

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/Users/pgalla2/snipeit.retry

default                    : ok=9    changed=8    unreachable=0    failed=1   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.