### PR TITLE
Refactor to addess issues #19 #23 #24

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ smtp_port: 25
 
 admin_first_name: Admin
 admin_last_name: Admin
+admin_user_name: admin
 admin_email: foo@example.com
 admin_password: bar
 

--- a/snipeit.yml
+++ b/snipeit.yml
@@ -1,33 +1,43 @@
 ---
-- hosts: snipeit 
+- hosts: snipeit
   sudo: true
 
   vars:
 
     snipeit_source: /opt/snipe-it
-
+    snipeit_version: master
     snipeit_dbname: snipeit
     snipeit_dbuser: snipeit
-    snipeit_dbuser_password: secret
 
-    smtp_host: smtp.example.com
+    smtp_host: []
     smtp_port: 25
 
     admin_first_name: Admin
     admin_last_name: Admin
-    admin_email: foo@example.com
-    admin_password: bar
+    admin_email: "{{ lookup('env', 'GIT_AUTHOR_EMAIL') }}"
+    admin_user_name: "{{ lookup('env', 'USERNAME') }}"
 
     disable_default_apache_site: True
-    run_mysql_on_all_interfaces: False
+    run_mysql_on_all_interfaces: True
+# If you want to import users from Active Directory to Snipe-IT, change ldap: to true and modify the below values.
+# To import AD users, run /usr/local/bin/import_ad_users.py
+    ldap: false
+    ldap_uri: []
+    ldap_admin: 'CN=Administrator,DC=foo,DC=com'
+    ldap_passwd: 'your_secret_password'
+    users_ou: 'OU=Users,DC=foo,DC=com'
 
-    # If you want to import users from Active Directory to Snipe-IT, uncomment and modify the below values.
-    # To import AD users, run /usr/local/bin/import_ad_users.py
+  vars_prompt:
 
-    #ldap_uri: 'ldap://dc01.foo.com'
-    #ldap_admin: 'CN=Administrator,DC=foo,DC=com'
-    #ldap_passwd: 'your_secret_password'
-    #users_ou: 'OU=Users,DC=foo,DC=com'
+    - name: "snipeit_dbuser_password"
+      prompt: "Enter snipeit_dbuser_password"
+      default: "changeme"
+      private: yes
+
+    - name: "admin_password"
+      prompt: "Enter admin_password"
+      default: "changeme"
+      private: yes
 
   roles:
     - snipeit-ansible

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,4 +108,4 @@
 
 - name: Install AD Users Import script
   include: import_ad_users.yml
-  when: ldap_uri is defined
+  when: ldap

--- a/templates/artisan_expect.exp.j2
+++ b/templates/artisan_expect.exp.j2
@@ -4,10 +4,10 @@ spawn php artisan app:install
 
 expect "Please enter your first name:" {send "{{ admin_first_name }}\r"}
 expect "Please enter your last name:" {send "{{ admin_last_name }}\r"}
-expect "Please enter your user email:" {send "{{ admin_email }}\r"}
+expect "Please enter your username:" {send "{{ admin_user_name }}\r"}
+expect "Please enter your email:" {send "{{ admin_email }}\r"}
 expect "Please enter your user password (at least 8 characters):" {send "{{ admin_password }}\r"}
-expect "Do you want to seed your database with dummy data? (deafult is yes):" {send "yes\r"}
-expect "Do you really wish to run this command?" {send "yes\r"}
-expect "Do you really wish to run this command?" {send "yes\r"}
+expect "Please confirm your user password:" {send "{{ admin_password }}\r"}
+expect "Do you want to seed your database with dummy data? y/N (default is no):" {send "y\r"}
 
 expect eof


### PR DESCRIPTION
Hi,

To fix: https://github.com/GR360RY/snipeit-ansible/issues/19 ; as this is due to changes in the questions 

ldapdict seems to have 'gone away' , to work around this: 
created the ldap: var and use this for the conditional (saves on [un]commenting as well).

Added some env lookups (will use the defaults/main.yml vars if they don't exist, i.e. the GIT_AUTHOR_EMAIL)

Added vars_prompt (with accompanying defaults) for passwords.