### PR TITLE
Set the timeout to forever to allow the migrations to finish

### DIFF
--- a/templates/artisan_expect.exp.j2
+++ b/templates/artisan_expect.exp.j2
@@ -1,5 +1,5 @@
 #!/usr/bin/expect
-
+set timeout -1
 spawn php artisan app:install
 
 expect "Please enter your first name:" {send "{{ admin_first_name }}\r"}


### PR DESCRIPTION
Expect has a default timeout of 10 seconds which was preventing some of the migrations scripts from getting executed. By setting it to -1 expect will wait until the migrations have finished. 